### PR TITLE
Update actions to latest version

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,18 +14,13 @@ jobs:
 
     steps:
       - name: 'Checkout the repository'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: 'Setup Node.JS'
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '14'
-
-      - name: 'Cache dependencies'
-        uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+          cache: yarn
 
       - name: 'Install dependencies'
         run: yarn install --frozen-lockfile
@@ -34,7 +29,7 @@ jobs:
         run: yarn test --coverage
 
       - name: 'Save test coverage'
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
 
       - name: 'Check code formatting'
         run: yarn format:check


### PR DESCRIPTION
This workflow still used `actions/cache@v2` which will [stop working in February](https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/). `actions/cache` is also no longer required, because `actions/setup-node` handles caching dependencies.

The other used actions are also still using node 12 and were automatically running as node 20, which might break them in weird ways that are difficult to detect.

Upgrading `codecov/codecov-action` from `v2` to `v5` introduced a few major changes, one of which is that `v4` now always requires a token, but `v5` relaxed that again. I'm not sure if you have a token setup already, or if you need to change anything in your codecov settings. The Migration Guide is here: https://github.com/codecov/codecov-action/tree/v5?tab=readme-ov-file#v5-release